### PR TITLE
Fixa tillåt tecken i text

### DIFF
--- a/LMS.Shared/DTOs/ManipulateBaseDto.cs
+++ b/LMS.Shared/DTOs/ManipulateBaseDto.cs
@@ -9,14 +9,12 @@ namespace LMS.Shared.DTOs
         [StringLength(Constants.NameMaxLength, MinimumLength = Constants.TextMinLength,
          ErrorMessage = "{0} must be between {2} and {1} characters.")]
         [NotOnlyWhitespace]
-        [RegularExpression(@"^[a-zA-Z0-9\s.\-/*"",:!?^]+$", ErrorMessage = "Name contains invalid characters. Only letters, numbers, spaces, and the following characters are allowed: . - / * , : ! ? ^ and double quotes")] // Against harmful strings, like html for XSS
         public string Name { get; init; } = string.Empty;
 
         [Required(ErrorMessage = "Description is a required field.")]
         [StringLength(Constants.NameMaxLength, MinimumLength = Constants.TextMinLength,
          ErrorMessage = "{0} must be between {2} and {1} characters.")]
         [NotOnlyWhitespace]
-        [RegularExpression(@"^[a-zA-Z0-9\s.\-/*"",:!?^]+$", ErrorMessage = "Description contains invalid characters. Only letters, numbers, spaces, and the following characters are allowed: . - / * , : ! ? ^  and double quotes")] // Against harmful strings, like html for XSS
         public string Description { get; init; } = string.Empty;
     }
 }


### PR DESCRIPTION
Tog bort regex-validering mot t.ex. XSS för jag upptäckte att det redan escapas tillräckligt och motverkas av ramverken i vårt fall. Möjligen kan vi ha kvar dem om vi helt enkelt vill att namnet eller beskrivningen bara ska få innehålla vissa tecken, bortom säkerhetsaspekten.