### PR TITLE
Endpoint till att hämta alla moduler för en kurs

### DIFF
--- a/Domain.Contracts/Repositories/IModuleRepository.cs
+++ b/Domain.Contracts/Repositories/IModuleRepository.cs
@@ -1,16 +1,12 @@
 ﻿using Domain.Models.Entities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Domain.Contracts.Repositories
 {
-    public  interface IModuleRepository : IRepositoryBase<Module>
+    public interface IModuleRepository : IRepositoryBase<Module>
     {
         Task<Module?> GetModuleAsync(Guid moduleId, bool trackChanges = false);
         Task<IEnumerable<Module>> GetAllModulesAsync();
+        Task<IEnumerable<Module>> GetModulesByCourseIdAsync(Guid courseId);
         Task AddAsync(Module module);
         void Remove(Module module);
     }

--- a/LMS.Infractructure/Repositories/ModuleRepository.cs
+++ b/LMS.Infractructure/Repositories/ModuleRepository.cs
@@ -11,21 +11,31 @@ namespace LMS.Infractructure.Repositories
         {
         }
 
+
         public async Task<Module?> GetModuleAsync(Guid moduleId, bool trackChanges = false)
         {
             return await FindAll(trackChanges).FirstOrDefaultAsync(m => m.Id == moduleId);
         }
+
 
         public async Task<IEnumerable<Module>> GetAllModulesAsync()
         {
             return await FindAll().Include(m => m.Course).ToListAsync();
         }
 
+
+        public async Task<IEnumerable<Module>> GetModulesByCourseIdAsync(Guid courseId)
+        {
+            return await FindByCondition(m => m.CourseId == courseId).ToListAsync();
+        }
+
+
         public async Task AddAsync(Module module)
         {
             Create(module);
             await Task.CompletedTask;
         }
+
 
         public void Remove(Module module)
         {

--- a/LMS.Presentation/Controllers/CourseController.cs
+++ b/LMS.Presentation/Controllers/CourseController.cs
@@ -30,6 +30,7 @@ namespace LMS.API
             return Ok(await _serviceManager.CourseService.GetAllCoursesAsync());
         }
 
+
         [HttpGet("my")]
         [Authorize]
         [SwaggerOperation(Summary = "Get coursedetails for user", Description = "Returns the users coursedetails")]

--- a/LMS.Presentation/Controllers/ModuleController.cs
+++ b/LMS.Presentation/Controllers/ModuleController.cs
@@ -35,7 +35,7 @@ namespace LMS.Presentation.Controllers
         [Authorize]
         [SwaggerOperation(Summary = "Get modules by course ID", Description = "Gets modules for a course")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public async Task<IActionResult> GetModulesBCourseId(Guid courseId)
+        public async Task<IActionResult> GetModulesByCourseId(Guid courseId)
         {
             var modules = await _serviceManager.ModuleService.GetModulesByCourseIdAsync(courseId);
             return Ok(modules);

--- a/LMS.Presentation/Controllers/ModuleController.cs
+++ b/LMS.Presentation/Controllers/ModuleController.cs
@@ -20,14 +20,27 @@ namespace LMS.Presentation.Controllers
             _serviceManager = serviceManager;
         }
 
+
         [HttpGet]
         [Authorize]
-        [SwaggerOperation(Summary = "Get all module", Description = "Gets all module")]
+        [SwaggerOperation(Summary = "Get all modules", Description = "Gets all modules")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> GetAllModules()
         {
             return Ok(await _serviceManager.ModuleService.GetAllModulesAsync());
         }
+
+
+        [HttpGet("{courseId}/modules")]
+        [Authorize]
+        [SwaggerOperation(Summary = "Get modules by course ID", Description = "Gets modules for a course")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetModulesBCourseId(Guid courseId)
+        {
+            var modules = await _serviceManager.ModuleService.GetModulesByCourseIdAsync(courseId);
+            return Ok(modules);
+        }
+
 
         [HttpGet("{id}")]
         [Authorize]
@@ -41,6 +54,7 @@ namespace LMS.Presentation.Controllers
                 return NotFound();
             return Ok(module);
         }
+
 
         [HttpPost]
         [Authorize(Roles = "Teacher")]
@@ -60,6 +74,7 @@ namespace LMS.Presentation.Controllers
             }
         }
 
+
         [HttpPut("{id}")]
         [Authorize(Roles = "Teacher")]
         [SwaggerOperation(Summary = "Update module", Description = "Updates an existing module by ID.")]
@@ -71,6 +86,7 @@ namespace LMS.Presentation.Controllers
             await _serviceManager.ModuleService.PutModuleAsync(id, dto);
             return NoContent();
         }
+
 
         [HttpDelete("{id}")]
         [Authorize(Roles = "Teacher")]

--- a/LMS.Services/ModuleService.cs
+++ b/LMS.Services/ModuleService.cs
@@ -11,11 +11,13 @@ namespace LMS.Services
         private readonly IUnitOfWork _unitOfWork;
         private readonly IMapper _mapper;
 
+
         public ModuleService(IUnitOfWork unitOfWork, IMapper mapper)
         {
             _unitOfWork = unitOfWork;
             _mapper = mapper;
         }
+
 
         public async Task<IEnumerable<ModuleDto>> GetAllModulesAsync()
         {
@@ -23,7 +25,15 @@ namespace LMS.Services
             return _mapper.Map<IEnumerable<ModuleDto>>(modules);
         }
 
-    public async Task<ModuleDto?> GetModuleAsync(Guid moduleId)
+
+        public async Task<IEnumerable<ModuleDto>> GetModulesByCourseIdAsync(Guid courseId)
+        {
+            var modules = await _unitOfWork.Modules.GetModulesByCourseIdAsync(courseId);
+            return _mapper.Map<IEnumerable<ModuleDto>>(modules);
+        }
+
+
+        public async Task<ModuleDto?> GetModuleAsync(Guid moduleId)
         {
             var module = await _unitOfWork.Modules.GetModuleAsync(moduleId);
             if (module == null)
@@ -31,6 +41,7 @@ namespace LMS.Services
 
             return _mapper.Map<ModuleDto>(module);
         }
+
 
         public async Task<ModuleDto> PostModuleAsync(CreateModuleDto dto)
         {
@@ -45,6 +56,7 @@ namespace LMS.Services
 
             return _mapper.Map<ModuleDto>(module);
         }
+
 
         public async Task PutModuleAsync(Guid id, UpdateModuleDto dto)
         {
@@ -67,6 +79,7 @@ namespace LMS.Services
                     throw;
             }
         }
+
 
         public async Task DeleteModuleAsync(Guid moduleId)
         {

--- a/Service.Contracts/IModuleService.cs
+++ b/Service.Contracts/IModuleService.cs
@@ -5,6 +5,7 @@ namespace Service.Contracts
     public interface IModuleService
     {
         Task<ModuleDto> GetModuleAsync(Guid moduleId);
+        Task<IEnumerable<ModuleDto>> GetModulesByCourseIdAsync(Guid courseId);
         Task<IEnumerable<ModuleDto>> GetAllModulesAsync();
         Task<ModuleDto> PostModuleAsync(CreateModuleDto dto);
         Task PutModuleAsync(Guid id, UpdateModuleDto dto);


### PR DESCRIPTION
Hela kedjan från repository till controller är tillagt enligt stilen i backendet. Modul-objekten inkluderar inte aktiviteter, men dock fältet activities med en tom array likt den endpointen som hämtar alla moduler generellt.